### PR TITLE
Return empty String from getAllResponseHeaders

### DIFF
--- a/Source/Ejecta/EJUtils/EJBindingHttpRequest.m
+++ b/Source/Ejecta/EJUtils/EJBindingHttpRequest.m
@@ -185,7 +185,7 @@ EJ_BIND_FUNCTION(abort, ctx, argc, argv) {
 
 EJ_BIND_FUNCTION(getAllResponseHeaders, ctx, argc, argv) {
 	if( !response || ![response isKindOfClass:[NSHTTPURLResponse class]] ) {
-		return NULL;
+		NSStringToJSValue(ctx, @"");
 	}
 	
 	NSHTTPURLResponse *urlResponse = (NSHTTPURLResponse *)response;


### PR DESCRIPTION
To bring it  closer to the browser implementation in the case of loading a local file.

As per https://github.com/phoboslab/Ejecta/issues/533.
